### PR TITLE
Bump libzip to 1.11.1

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_LibZipSharpAssemblyVersionMajor>3</_LibZipSharpAssemblyVersionMajor>
-    <_LibZipSharpAssemblyVersionMinor>4</_LibZipSharpAssemblyVersionMinor>
+    <_LibZipSharpAssemblyVersionMinor>5</_LibZipSharpAssemblyVersionMinor>
     <_LibZipSharpAssemblyVersionPatch>0</_LibZipSharpAssemblyVersionPatch>
     <_LibZipSharpAssemblyVersion>$(_LibZipSharpAssemblyVersionMajor).$(_LibZipSharpAssemblyVersionMinor).$(_LibZipSharpAssemblyVersionPatch)</_LibZipSharpAssemblyVersion>
     <_NativeLibraryVersionForName>$(_LibZipSharpAssemblyVersionMajor)-$(_LibZipSharpAssemblyVersionMinor)</_NativeLibraryVersionForName>

--- a/LibZipSharp/Xamarin.Tools.Zip/ErrorCode.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ErrorCode.cs
@@ -202,5 +202,20 @@ namespace Xamarin.Tools.Zip
 		/// Operation cancelled
 		/// </summary>
 		Cancelled      = 32,
+
+		/// <summary>
+		/// Unexpected length of data
+		/// </summary>
+		DataLength     =  33,
+
+		/// <summary>
+		/// Not allowed in torrentzip
+		/// </summary>
+		NotAllowed     = 34,
+
+		/// <summary>
+		/// Possibly truncated or corrupted zip archive
+		/// </summary>
+		TruncatedZip   =  35,
 	}
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,28 +88,26 @@ extends:
               inputs:
                 rootFolderOrFile: lzsbuild\lib\win32\RelWithDebInfo\
                 includeRootFolder: false
-                archiveType: 7z
+                archiveType: tar
+                tarCompression: bz2
                 replaceExistingArchive: true
-                archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-x86.7z
+                archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-x86.tar.bz2
             - task: ArchiveFiles@2
               inputs:
                 rootFolderOrFile: lzsbuild\lib\win64\RelWithDebInfo\
                 includeRootFolder: false
-                archiveType: 7z
+                archiveType: tar
+                tarCompression: bz2
                 replaceExistingArchive: true
-                archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-x64.7z
+                archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-x64.tar.bz2
             - task: ArchiveFiles@2
               inputs:
                 rootFolderOrFile: lzsbuild\lib\winarm64\RelWithDebInfo\
                 includeRootFolder: false
-                archiveType: 7z
+                archiveType: tar
+                tarCompression: bz2
                 replaceExistingArchive: true
-                archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-arm-x64.7z
-            - script: |
-                7z t $(Build.ArtifactStagingDirectory)\libzip-windows-arm-x64.7z
-                7z t $(Build.ArtifactStagingDirectory)\libzip-windows-x64.7z
-                7z t $(Build.ArtifactStagingDirectory)\libzip-windows-x86.7z
-              displayName: Test Archives
+                archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-arm-x64.tar.bz2
 
         - job: buildLinux
           pool:
@@ -136,9 +134,10 @@ extends:
               inputs:
                 rootFolderOrFile: lzsbuild/lib/Linux/
                 includeRootFolder: false
-                archiveType: 7z
+                archiveType: tar
+                tarCompression: bz2
                 replaceExistingArchive: true
-                archiveFile: $(Build.ArtifactStagingDirectory)/libzip-linux-x64.7z
+                archiveFile: $(Build.ArtifactStagingDirectory)/libzip-linux-x64.tar.bz2
 
         - job: buildMacOS
           dependsOn:
@@ -179,26 +178,26 @@ extends:
             - task: ExtractFiles@1
               displayName: Extract 64 bit Linux native
               inputs:
-                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-linux-x64.7z
+                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-linux-x64.tar.bz2
                 destinationFolder: lzsbuild/lib/Linux
             - task: ExtractFiles@1
               displayName: Extract 64 bit Windows native
               inputs:
-                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-windows-x64.7z
+                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-windows-x64.tar.bz2
                 destinationFolder: lzsbuild/lib/win64
             - task: ExtractFiles@1
               displayName: Extract 64 bit ARM Windows native
               inputs:
-                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-windows-arm-x64.7z
+                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-windows-arm-x64.tar.bz2
                 destinationFolder: lzsbuild/lib/winarm64
             - task: ExtractFiles@1
               displayName: Extract 32 bit Windows native
               inputs:
-                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-windows-x86.7z
+                archiveFilePatterns: $(Build.ArtifactStagingDirectory)/libzip-windows-x86.tar.bz2
                 destinationFolder: lzsbuild/lib/win32
             - bash: |
-                rm $(Build.ArtifactStagingDirectory)/libzip-linux-*.7z
-                rm $(Build.ArtifactStagingDirectory)/libzip-windows-*.7z
+                rm $(Build.ArtifactStagingDirectory)/libzip-linux-*.tar.bz2
+                rm $(Build.ArtifactStagingDirectory)/libzip-windows-*.tar.bz2
               displayName: 'Find libzip'
             - task: DotNetCoreCLI@2
               displayName: 'Build solution libZipSharp.csproj'


### PR DESCRIPTION
Changes: https://libzip.org/news/release-1.11.html
Changes: https://libzip.org/news/release-1.11.1.html
    
A handful of improvements that don't directly affect us, however we
missed a handful of new error codes, added now.

Bumps LibZipSharp version to 3.5.0, because of the new version of
libzip.
