### PR TITLE
Some minor performance changes for .net6+

### DIFF
--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -330,7 +330,7 @@ namespace Tests {
 		}
 
 		[Test]
-		public void InMemoryZipFile ()
+		public void InMemoryZipFile ([Values (true, false)] bool useTempFile)
 		{
 			string filePath = Path.GetFullPath ("info.json");
 			if (!File.Exists (filePath)) {
@@ -338,14 +338,14 @@ namespace Tests {
 			}
 			string fileRoot = Path.GetDirectoryName (filePath);
 			using (var stream = new MemoryStream ()) {
-				using (var zip = ZipArchive.Create (stream)) {
+				using (var zip = ZipArchive.Create (stream, useTempFile: useTempFile)) {
 					zip.AddFile (filePath, "info.json");
 					zip.AddFile (Path.Combine (fileRoot, "characters_players.json"), "characters_players.json");
 					zip.AddFile (Path.Combine (fileRoot, "object_spawn.json"), "object_spawn.json");
 				}
 
 				stream.Position = 0;
-				using (var zip = ZipArchive.Open (stream, strictConsistencyChecks: true)) {
+				using (var zip = ZipArchive.Open (stream, strictConsistencyChecks: true, useTempFile: useTempFile)) {
 					Assert.AreEqual (3, zip.EntryCount);
 					foreach (var e in zip) {
 						Console.WriteLine (e.FullName);
@@ -354,13 +354,13 @@ namespace Tests {
 				}
 
 				stream.Position = 0;
-				using (var zip = ZipArchive.Open (stream, strictConsistencyChecks: true)) {
+				using (var zip = ZipArchive.Open (stream, strictConsistencyChecks: true, useTempFile: useTempFile)) {
 					Assert.AreEqual (2, zip.EntryCount);
 					zip.AddEntry ("info.json", File.ReadAllText (filePath), Encoding.UTF8, CompressionMethod.Deflate);
 				}
 
 				stream.Position = 0;
-				using (var zip = ZipArchive.Open (stream)) {
+				using (var zip = ZipArchive.Open (stream, useTempFile: useTempFile)) {
 					Assert.AreEqual (3, zip.EntryCount);
 					Assert.IsTrue (zip.ContainsEntry ("info.json"));
 					var entry1 = zip.ReadEntry ("info.json");

--- a/LibZipSharp/Xamarin.Tools.Zip/IPlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/IPlatformServices.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Tools.Zip
 		bool SetEntryPermissions (ZipArchive archive, ulong index, EntryPermissions permissions, bool isDirectory);
 		bool ReadAndProcessExtraFields (ZipEntry entry);
 		bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields);
+		bool WriteExtraFields (ZipArchive archive, ZipEntry entry, params ExtraField[] extraFields);
 		bool SetFileProperties (ZipEntry entry, string extractedFilePath, bool throwOnNativeErrors);
 		bool ExtractSpecialFile (ZipEntry entry, string destinationDir);
 	}

--- a/LibZipSharp/Xamarin.Tools.Zip/PlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/PlatformServices.cs
@@ -137,6 +137,14 @@ namespace Xamarin.Tools.Zip
 			CallServices ((IPlatformServices services) => services.ReadAndProcessExtraFields (entry));
 		}
 
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields)
+		{
+			if (entry == null)
+				throw new ArgumentNullException (nameof (entry));
+
+			return CallServices ((IPlatformServices services) => services.WriteExtraFields (archive, entry, extraFields));
+		}
+
 		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, params ExtraField[] extraFields)
 		{
 			if (entry == null)

--- a/LibZipSharp/Xamarin.Tools.Zip/PlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/PlatformServices.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Tools.Zip
 			CallServices ((IPlatformServices services) => services.ReadAndProcessExtraFields (entry));
 		}
 
-		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields = null)
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, params ExtraField[] extraFields)
 		{
 			if (entry == null)
 				throw new ArgumentNullException (nameof (entry));

--- a/LibZipSharp/Xamarin.Tools.Zip/UnixPlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/UnixPlatformServices.cs
@@ -301,6 +301,11 @@ namespace Xamarin.Tools.Zip
 
 		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields)
 		{
+			return WriteExtraFields (archive, entry, extraFields.ToArray ());
+		}
+
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, params ExtraField[] extraFields)
+		{
 			if (entry == null)
 				return false;
 

--- a/LibZipSharp/Xamarin.Tools.Zip/UnixZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/UnixZipArchive.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Tools.Zip
 		{
 		}
 
-		internal UnixZipArchive (Stream stream, UnixPlatformOptions options, OpenFlags flags) : base (stream, options, flags)
+		internal UnixZipArchive (Stream stream, UnixPlatformOptions options, OpenFlags flags, bool useTempFile) : base (stream, options, flags, useTempFile)
 		{
 		}
 

--- a/LibZipSharp/Xamarin.Tools.Zip/WindowsPlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/WindowsPlatformServices.cs
@@ -230,6 +230,11 @@ namespace Xamarin.Tools.Zip
 
 		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields)
 		{
+			return WriteExtraFields (archive, entry, extraFields.ToArray ());
+		}
+
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, params ExtraField[] extraFields)
+		{
 			if (entry == null)
 				return false;
 

--- a/LibZipSharp/Xamarin.Tools.Zip/WindowsZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/WindowsZipArchive.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Tools.Zip
 		{
 		}
 
-		internal WindowsZipArchive (Stream stream, WindowsPlatformOptions options, OpenFlags flags) : base (stream, options, flags)
+		internal WindowsZipArchive (Stream stream, WindowsPlatformOptions options, OpenFlags flags, bool useTempFile) : base (stream, options, flags, useTempFile)
 		{
 		}
 

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.Unix.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.Unix.cs
@@ -16,13 +16,13 @@ namespace Xamarin.Tools.Zip
 			}
 		}
 
-		static ZipArchive CreateInstanceFromStream (Stream stream, OpenFlags flags = OpenFlags.RDOnly, IPlatformOptions options = null)
+		static ZipArchive CreateInstanceFromStream (Stream stream, OpenFlags flags = OpenFlags.RDOnly, IPlatformOptions options = null, bool useTempFile = true)
 		{
 			if (Environment.OSVersion.Platform == PlatformID.Unix) {
-				return new UnixZipArchive (stream, EnsureOptions (options) as UnixPlatformOptions, flags);
+				return new UnixZipArchive (stream, EnsureOptions (options) as UnixPlatformOptions, flags, useTempFile);
 			}
 			else {
-				return new WindowsZipArchive (stream, EnsureOptions (options) as WindowsPlatformOptions, flags);
+				return new WindowsZipArchive (stream, EnsureOptions (options) as WindowsPlatformOptions, flags, useTempFile);
 			}
 		}
 

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -376,7 +376,7 @@ namespace Xamarin.Tools.Zip
 			long index = Native.zip_file_add (archive, destPath, source, overwriteExisting ? OperationFlags.Overwrite : OperationFlags.None);
 			if (index < 0)
 				throw GetErrorException ();
-			if (Native.zip_set_file_compression (archive, (ulong)index, compressionMethod, 9) < 0)
+			if (Native.zip_set_file_compression (archive, (ulong)index, compressionMethod, 0) < 0)
 				throw GetErrorException ();
 			if (permissions == EntryPermissions.Default)
 				permissions = DefaultFilePermissions;
@@ -457,7 +457,7 @@ namespace Xamarin.Tools.Zip
 			long index = PlatformServices.Instance.StoreSpecialFile (this, sourcePath, archivePath, out compressionMethod);
 			if (index < 0)
 				throw GetErrorException ();
-			if (Native.zip_set_file_compression (archive, (ulong)index, isDir ? CompressionMethod.Store : compressionMethod, 9) < 0)
+			if (Native.zip_set_file_compression (archive, (ulong)index, isDir ? CompressionMethod.Store : compressionMethod, 0) < 0)
 				throw GetErrorException ();
 			PlatformServices.Instance.SetEntryPermissions (this, sourcePath, (ulong)index, permissions);
 			ZipEntry entry = ReadEntry ((ulong)index);

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -803,8 +803,7 @@ namespace Xamarin.Tools.Zip
 
 		internal static unsafe Int64 stream_callback (IntPtr state, IntPtr data, UInt64 len, SourceCommand cmd)
 		{
-#if NET6_0_OR_GREATER
-#else
+#if !NET6_0_OR_GREATER
 			byte [] buffer = null;
 #endif
 			Native.zip_error_t error;

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -376,7 +376,7 @@ namespace Xamarin.Tools.Zip
 			long index = Native.zip_file_add (archive, destPath, source, overwriteExisting ? OperationFlags.Overwrite : OperationFlags.None);
 			if (index < 0)
 				throw GetErrorException ();
-			if (Native.zip_set_file_compression (archive, (ulong)index, compressionMethod, 0) < 0)
+			if (Native.zip_set_file_compression (archive, (ulong)index, compressionMethod, 9) < 0)
 				throw GetErrorException ();
 			if (permissions == EntryPermissions.Default)
 				permissions = DefaultFilePermissions;
@@ -457,7 +457,7 @@ namespace Xamarin.Tools.Zip
 			long index = PlatformServices.Instance.StoreSpecialFile (this, sourcePath, archivePath, out compressionMethod);
 			if (index < 0)
 				throw GetErrorException ();
-			if (Native.zip_set_file_compression (archive, (ulong)index, isDir ? CompressionMethod.Store : compressionMethod, 0) < 0)
+			if (Native.zip_set_file_compression (archive, (ulong)index, isDir ? CompressionMethod.Store : compressionMethod, 9) < 0)
 				throw GetErrorException ();
 			PlatformServices.Instance.SetEntryPermissions (this, sourcePath, (ulong)index, permissions);
 			ZipEntry entry = ReadEntry ((ulong)index);

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -382,13 +382,14 @@ namespace Xamarin.Tools.Zip
 				permissions = DefaultFilePermissions;
 			PlatformServices.Instance.SetEntryPermissions (this, (ulong)index, permissions, false);
 			ZipEntry entry = ReadEntry ((ulong)index);
-			IList<ExtraField> fields = new List<ExtraField> ();
 			ExtraField_ExtendedTimestamp timestamp = new ExtraField_ExtendedTimestamp (entry, 0, modificationTime: modificationTime ?? DateTime.UtcNow);
-			fields.Add (timestamp);
-			if (!PlatformServices.Instance.WriteExtraFields (this, entry, fields))
+			timestamp.Encode ();
+			if (!PlatformServices.Instance.WriteExtraFields (this, entry, timestamp)) {
 				throw GetErrorException ();
+			}
 			return entry;
 		}
+
 
 		/// <summary>
 		/// Adds the file to archive directory. The file is added to either the root directory of
@@ -461,16 +462,16 @@ namespace Xamarin.Tools.Zip
 				throw GetErrorException ();
 			PlatformServices.Instance.SetEntryPermissions (this, sourcePath, (ulong)index, permissions);
 			ZipEntry entry = ReadEntry ((ulong)index);
-			IList<ExtraField> fields = new List<ExtraField> ();
 			ExtraField_ExtendedTimestamp timestamp = new ExtraField_ExtendedTimestamp (
 				entry, 0,
 				createTime: File.GetCreationTimeUtc (sourcePath),
 				accessTime: File.GetLastAccessTimeUtc (sourcePath),
 				modificationTime: File.GetLastWriteTimeUtc (sourcePath)
 			);
-			fields.Add (timestamp);
-			if (!PlatformServices.Instance.WriteExtraFields (this, entry, fields))
+			timestamp.Encode ();
+			if (!PlatformServices.Instance.WriteExtraFields (this, entry, timestamp)) {
 				throw GetErrorException ();
+			}
 			return entry;
 		}
 
@@ -915,7 +916,7 @@ namespace Xamarin.Tools.Zip
 #if NET6_0_OR_GREATER
 					unsafe
 					{
-						byte* ptr = (byte*)data.ToPointer();
+						byte* ptr = (byte*)data;
 						int bytesRead = stream.Read(new Span<byte>(ptr, length));
 						return bytesRead;
 					}

--- a/ZipBenchmark/Performance.cs
+++ b/ZipBenchmark/Performance.cs
@@ -62,7 +62,7 @@ public class Performance
     public void LibZipSharpCreateZip ()
     {
         using var stream = new MemoryStream ();
-        using (var zip = ZipArchive.Create (stream, strictConsistencyChecks: false)) {
+        using (var zip = ZipArchive.Create (stream, strictConsistencyChecks: false, useTempFile: false)) {
             foreach (var file in files) {
                 zip.AddEntry (file.Value, file.Key);
             }
@@ -88,7 +88,7 @@ public class Performance
     {
         using var ms = new MemoryStream ();
         libZip!.Position = 0;
-        using (var zi = ZipArchive.Open (libZip)) {
+        using (var zi = ZipArchive.Open (libZip, useTempFile: false)) {
             foreach (var entry in zi) {
                 ms.Position= 0;
                 entry.Extract (ms);

--- a/ZipBenchmark/Performance.cs
+++ b/ZipBenchmark/Performance.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Xamarin.Tools.Zip;
+using SIOC = System.IO.Compression;
+
+[MemoryDiagnoser]
+public class Performance
+{
+
+    static byte [] data = [];
+    static Dictionary<string, byte []> files = new Dictionary<string, byte []> ();
+
+    static Stream? sicZip = null;
+    static Stream? libZip = null;
+
+    [GlobalSetup]
+    public void Setup ()
+    {
+        Random r = new Random (234234);
+        for (int j = 0; j < 100; j++) {
+            data = new byte [r.Next (100, 1024 * 1000)];
+            for (int i = 0; i < data.Length; i++)
+                data [i] = (byte)r.Next (0, 128);// Add a bunch of ascii characters.
+            files.Add ($"file-{j}.dat", data);
+        }
+        sicZip = new MemoryStream ();
+        using (var zip = new SIOC.ZipArchive (sicZip, SIOC.ZipArchiveMode.Create, leaveOpen: true)) {
+            foreach (var file in files) {
+                var entry = zip.CreateEntry (file.Key);
+                using (var writer = new StreamWriter (entry.Open ())) {
+                    writer.Write (file.Value);
+                }
+            }
+        }
+        libZip = new MemoryStream ();
+        using (var zip = ZipArchive.Create (libZip, strictConsistencyChecks: false)) {
+            foreach (var file in files) {
+                zip.AddEntry (file.Value, file.Key);
+            }
+            zip.Close ();
+        }
+    }
+
+    [Benchmark]
+    public void SystemIOCompressionCreateZip ()
+    {
+        using var stream = new MemoryStream ();
+        using (var zip = new SIOC.ZipArchive (stream, SIOC.ZipArchiveMode.Create)) {
+            foreach (var file in files) {
+                var entry = zip.CreateEntry (file.Key, SIOC.CompressionLevel.SmallestSize);
+                using (var writer = new StreamWriter (entry.Open ())) {
+                    writer.Write (file.Value);
+                }
+            }
+        }
+    }
+
+    [Benchmark]
+    public void LibZipSharpCreateZip ()
+    {
+        using var stream = new MemoryStream ();
+        using (var zip = ZipArchive.Create (stream, strictConsistencyChecks: false)) {
+            foreach (var file in files) {
+                zip.AddEntry (file.Value, file.Key);
+            }
+            zip.Close ();
+        }
+    }
+
+    [Benchmark]
+    public void SystemIOCompressionExtractToMemory ()
+    {
+        using var ms = new MemoryStream ();
+        sicZip!.Position = 0;
+        using (var zi = new SIOC.ZipArchive (sicZip, SIOC.ZipArchiveMode.Read, leaveOpen: true)) {
+            foreach (var entry in zi.Entries) {
+                ms.Position= 0;
+                entry.Open ().CopyTo (ms);
+            }
+        }
+    }
+
+    [Benchmark]
+    public void LibZipSharpExtractToMemory ()
+    {
+        using var ms = new MemoryStream ();
+        libZip!.Position = 0;
+        using (var zi = ZipArchive.Open (libZip)) {
+            foreach (var entry in zi) {
+                ms.Position= 0;
+                entry.Extract (ms);
+            }
+        }
+    }
+}

--- a/ZipBenchmark/Program.cs
+++ b/ZipBenchmark/Program.cs
@@ -44,14 +44,19 @@ class App
 {
 	public static int Main (string [] args)
         {
-		if (args.Length == 0) {
-			Console.WriteLine ($"Usage: ZipBenchmark path/to/a/large/file/to/compress");
-			Console.WriteLine ();
-			return 1;
-		}
+		// if (args.Length == 0) {
+		// 	Console.WriteLine ($"Usage: ZipBenchmark path/to/a/large/file/to/compress");
+		// 	Console.WriteLine ();
+		// 	return 1;
+		// }
 
-		LargeFileCompression.InputFilePath = args[0];
-		var summary = BenchmarkRunner.Run<LargeFileCompression> ();
+		// LargeFileCompression.InputFilePath = args[0];
+		var summary = BenchmarkRunner.Run<Performance> ();
+		// Console.WriteLine ("Running...");
+		// Console.ReadLine ();
+		// var p = new Performance ();
+		// p.Setup ();
+		// p.LibZipSharpCreateZip ();
 		return 0;
 	}
 }

--- a/libZipSharp.sln
+++ b/libZipSharp.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libZipSharp", "LibZipSharp\libZipSharp.csproj", "{E248B2CA-303B-4645-ADDC-9D4459D550FD}"
@@ -8,6 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTest", "UnitTest", "{6F41E830-1A60-4DE8-B061-10D9164D9F5B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibZipSharp.UnitTest", "LibZipSharp.UnitTest\LibZipSharp.UnitTest.csproj", "{E66B5FB9-2470-4563-BF28-0C57108369D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZipBenchmark", "ZipBenchmark\ZipBenchmark.csproj", "{A94C6974-76CE-4BA9-83A2-69FCBCA77118}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{E66B5FB9-2470-4563-BF28-0C57108369D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E66B5FB9-2470-4563-BF28-0C57108369D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E66B5FB9-2470-4563-BF28-0C57108369D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A94C6974-76CE-4BA9-83A2-69FCBCA77118}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A94C6974-76CE-4BA9-83A2-69FCBCA77118}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A94C6974-76CE-4BA9-83A2-69FCBCA77118}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A94C6974-76CE-4BA9-83A2-69FCBCA77118}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0


### PR DESCRIPTION
1. Add a new Benchmark
2. Add a useTempFile option to the constructors (breaks binary compatibility, need to add overrides). 
3. Some small performance enhancements to avoid doing Marshal.Copy.
4. Add a new WriteExtraFields which takes a `params` to allow us to simplify some code .