### PR TITLE
[ci] Add a schedule trigger for OneLocBuild

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,12 +4,24 @@ trigger:
       - main
       - refs/tags/*
 
+schedules:
+- cron: "0 6 * * *"
+  displayName: Run daily at 6:00 UTC
+  branches:
+    include:
+    - main
+- cron: "0 6 * * Sunday"
+  displayName: Run weekly on Sunday at 6:00 UTC
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
   repositories:
     - repository: internal-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
+      type: git
+      name: DevDiv/Xamarin.yaml-templates
       ref: refs/heads/main
     - repository: 1esPipelines
       type: git
@@ -132,7 +144,7 @@ extends:
     - stage: Compliance
       displayName: Compliance
       dependsOn: Build
-      condition: and(eq(dependencies.Build.result, 'Succeeded'), eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+      condition: and(eq(dependencies.Build.result, 'Succeeded'), eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'), ne(variables['Build.Reason'], 'Schedule'))
       jobs:
       - job: api_scan
         displayName: API Scan

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,7 @@ extends:
           use1ESTemplate: true
           signListPath: 'SignList.xml'
           templateResourceName: internal-templates
+          checkoutType: self
 
     - stage: Localization
       dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,7 @@ extends:
         os: windows
       sourceRepositoriesToScan:
         exclude:
+        - repository: yaml-templates
         - repository: internal-templates
     stages:
     - template: /yaml-templates/stage-build.yml@self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,6 @@ extends:
         os: windows
       sourceRepositoriesToScan:
         exclude:
-        - repository: yaml-templates
         - repository: internal-templates
     stages:
     - template: /yaml-templates/stage-build.yml@self
@@ -85,6 +84,7 @@ extends:
           usePipelineArtifactTasks: true
           use1ESTemplate: true
           signListPath: 'SignList.xml'
+          templateResourceName: internal-templates
 
     - stage: Localization
       dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,9 @@ extends:
         name: AzurePipelines-EO
         image: $(WindowsPoolImage1ESPT)
         os: windows
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: internal-templates
     stages:
     - template: /yaml-templates/stage-build.yml@self
 


### PR DESCRIPTION
Adds a schedule trigger to ensure the OneLocBuild task runs regularly, which should ensure it stays active to the loc system.

The compliance stage condition has been adjusted so that it will be skipped when running a scheduled build.

The build will also use the new internal yaml-templates repo.